### PR TITLE
chore: Add package-lock.json into gitignore, Add host option into dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ dist-ssr
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",


### PR DESCRIPTION
충돌방지를 위한 설정과 내부 네트워크에서 모바일 테스트를 편하게 할 수 있게 하였습니다.


## 변경사항
- gitignore에 package-lock.json 추가
- package.json dev 스트립트에 --host 옵션추가